### PR TITLE
Update package form to add custom extras fields and state form to deleted datasets

### DIFF
--- a/ckanext/scheming/templates/scheming/package/snippets/package_form.html
+++ b/ckanext/scheming/templates/scheming/package/snippets/package_form.html
@@ -48,7 +48,24 @@
     <input type="hidden" name="_ckan_phase" value="" />
   {%- endif -%}
 
+  {% if data.id and h.check_access('package_delete', {'id': data.id}) and data.state != 'active' %}
+    <div class="control-group form-group control-medium">
+      <label for="field-state" class="control-label">{{ _('State') }}</label>
+      <div class="controls">
+        <select class="form-control" id="field-state" name="state">
+          <option value="active" {% if data.get('state', 'none') == 'active' %} selected="selected" {% endif %}>{{ _('Active') }}</option>
+          <option value="deleted" {% if data.get('state', 'none') == 'deleted' %} selected="selected" {% endif %}>{{ _('Deleted') }}</option>
+        </select>
+      </div>
+    </div>
+  {% endif %}
+
 {% endblock %}
 
 {% block metadata_fields %}
+  {% block package_metadata_fields_custom %}
+    {% block custom_fields %}
+      {% snippet 'snippets/custom_form_fields.html', extras=data.extras, errors=errors, limit=3 %}
+    {% endblock %}
+  {% endblock %}
 {% endblock %}


### PR DESCRIPTION
## Description
This PR updates the package form to add the custom extras fields and adds the state dropdown form field to deleted datasets. Both templates come from default templates in CKAN.

The custom fields come from the `package_metadata_fields` template snippet. This adds the custom key, value text form to the bottom of the dataset form.
https://github.com/ckan/ckan/blob/2.9/ckan/templates/package/snippets/package_metadata_fields.html#L25-L29

The state field comes from the `package_basic_fields` template snippet. This will add a dropdown menu for changing states ['active', 'deleted'] in the deleted dataset edit page.
https://github.com/ckan/ckan/blob/2.9/ckan/templates/package/snippets/package_basic_fields.html#L115-L125